### PR TITLE
chore: tmuxifier setup

### DIFF
--- a/docs/tmux-setup.md
+++ b/docs/tmux-setup.md
@@ -7,7 +7,7 @@ This setup is completely optional. Tmux just makes it easier to setup and manage
 - **tmux**
   - Install via [tmux repo](https://github.com/tmux/tmux/wiki/Installing)
   - Good setup to follow [here](https://www.youtube.com/watch?v=jaI3Hcw-ZaA)
-- **tmuxifier+** - Installed via tpm (installed in step above)
+- **tmuxifier** - Installed via tpm (installed in step above)
 
 ## Getting Started
 

--- a/docs/tmux-setup.md
+++ b/docs/tmux-setup.md
@@ -1,0 +1,25 @@
+# Tmux Setup
+
+This setup is completely optional. Tmux just makes it easier to setup and manage the project dev env.
+
+## Prerequisites
+
+- **tmux**
+  - Install via [tmux repo](https://github.com/tmux/tmux/wiki/Installing)
+  - Good setup to follow [here](https://www.youtube.com/watch?v=jaI3Hcw-ZaA)
+- **tmuxifier+** - Installed via tpm (installed in step above)
+
+## Getting Started
+
+```bash
+# Navigate to the project and copy the contents of the example file
+cd core && pbcopy < mhl-core.session.sh.example
+
+# Create a new tmuxifier config and replace the contents with the copied file
+# And replace the project placeholder <PATH-TO-REPO> with the correct one
+tmuxifier ns mhl-core
+
+# Start development (server + client)
+tmuxifier s mhl-core
+```
+

--- a/mhl-core.session.sh.example
+++ b/mhl-core.session.sh.example
@@ -1,0 +1,23 @@
+# Set a custom session root path. Default is `$HOME`.
+# Must be called before `initialize_session`.
+session_root "<PATH-TO-REPO>/src/"
+
+# Create session with specified name if it does not already exist. If no
+# argument is given, session name will be based on layout file name.
+if initialize_session "mhl-core"; then
+
+  new_window "editor"
+  new_window "dev"
+  new_window "gen-cmd"
+
+  select_window 3
+  run_cmd "nvm use"
+  select_window 2
+  run_cmd "nvm use && pnpm dev"
+  select_window 1
+  run_cmd "nvm use && nvim"
+
+fi
+
+# Finalize session creation and switch/attach to it.
+finalize_and_go_to_session


### PR DESCRIPTION
## What?

Closes #6 

Adds optional tmuxifier session preset and setup documentation for quick dev environment setup.

## Why?

Developer convenience - allows setting up the full dev environment (editor, server, client) with a single command. Reduces friction for developers who use tmux.

## How?

- Added `mhl-core.session.sh.example` - tmuxifier session template with:
  - Window 1: Editor (nvim)
  - Window 2: Dev server (pnpm dev)
  - Window 3: General terminal
- Added `docs/tmux-setup.md` - setup instructions for tmux/tmuxifier

## Testing Instructions

1. Ensure tmux and tmuxifier are installed
2. Copy the example file: `pbcopy < mhl-core.session.sh.example`
3. Create tmuxifier config: `tmuxifier ns mhl-core`
4. Paste and replace `<PATH-TO-REPO>` with actual path
5. Start session: `tmuxifier s mhl-core`
6. Verify all windows open correctly with proper commands

## Screenshots or screencast

N/A - Optional developer tooling